### PR TITLE
Add `-frag HCD` to EncyclopeDIA local searches

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -70,7 +70,7 @@ params {
         chrlib_postfix = 'chr'
         quant_postfix = 'quant'
         global_postfix = 'global'
-        local_options = ''
+        local_options = '-frag HCD'
         global_options = ''
     }
 


### PR DESCRIPTION
This is not the main issue we're running into, but will improve our results a bit.