### PR TITLE
Downgrade to OpenJDK 11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
   - r
 dependencies:
   # Main dependencies:
+  - openjdk=11.0.15
   - encyclopedia=1.12.34
   - bioconductor-msstats=4.2.0
   - r-tidyverse


### PR DESCRIPTION
For some reason I get Java errors on AWS with OpenJDK 17. 