### PR TITLE
Overhauled the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,38 @@
-FROM mambaorg/micromamba:latest
+ARG VERSION=1.12.34
+
+FROM mambaorg/micromamba:latest as micromamba
+FROM searlelab/encyclopedia:$VERSION
 LABEL authors="wfondrie@talus.bio" \
       description="Docker image for most of nf-encyclopedia"
-
-USER root
-COPY environment.yml /tmp/environment.yml
 
 # Install procps so that Nextflow can poll CPU usage and
 # deep clean the apt cache to reduce image/layer size
 RUN apt-get update \
-    && apt-get install -y procps libgomp1 \
+    && apt-get install -y procps sqlite3 \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Setup micromamba:
+ARG MAMBA_USER=mamba
+ARG MAMBA_USER_ID=1000
+ARG MAMBA_USER_GID=1000
+ENV MAMBA_USER=$MAMBA_USER
+ENV MAMBA_ROOT_PREFIX="/opt/conda"
+ENV MAMBA_EXE="/bin/micromamba"
+
+COPY --from=micromamba "$MAMBA_EXE" "$MAMBA_EXE"
+COPY --from=micromamba /usr/local/bin/_activate_current_env.sh /usr/local/bin/_activate_current_env.sh
+COPY --from=micromamba /usr/local/bin/_dockerfile_shell.sh /usr/local/bin/_dockerfile_shell.sh
+COPY --from=micromamba /usr/local/bin/_entrypoint.sh /usr/local/bin/_entrypoint.sh
+COPY --from=micromamba /usr/local/bin/_activate_current_env.sh /usr/local/bin/_activate_current_env.sh
+COPY --from=micromamba /usr/local/bin/_dockerfile_initialize_user_accounts.sh /usr/local/bin/_dockerfile_initialize_user_accounts.sh
+COPY --from=micromamba /usr/local/bin/_dockerfile_setup_root_prefix.sh /usr/local/bin/_dockerfile_setup_root_prefix.sh
+
+RUN /usr/local/bin/_dockerfile_initialize_user_accounts.sh && \
+    /usr/local/bin/_dockerfile_setup_root_prefix.sh
+
+# Setup the environment
+USER root
+COPY environment.yml /tmp/environment.yml
 
 # Instruct R processes to use these empty files instead of
 # clashing with a local one
@@ -21,4 +44,9 @@ RUN micromamba install -y -n base -f /tmp/environment.yml && \
 
 # Set the path. NextFlow seems to circumvent the conda environment
 # We also need to set options for the JRE here.
-ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH" _JAVA_OPTIONS="-Djava.awt.headless=true"
+ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH" _JAVA_OPTIONS="-Djava.awt.headless=true" VERSION=$VERSION
+
+# Create the entrypoint:
+SHELL ["/usr/local/bin/_dockerfile_shell.sh"]
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN touch .Rprofile .Renviron
 RUN micromamba install -y -n base -f /tmp/environment.yml && \
     micromamba clean --all --yes
 
+# Setup the EncyclopeDIA executable:
+RUN ln -s /code/encyclopedia-$VERSION-executable.jar ./encyclopedia.jar
+
 # Set the path. NextFlow seems to circumvent the conda environment
 # We also need to set options for the JRE here.
 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH" _JAVA_OPTIONS="-Djava.awt.headless=true" VERSION=$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN micromamba install -y -n base -f /tmp/environment.yml && \
     micromamba clean --all --yes
 
 # Setup the EncyclopeDIA executable:
-RUN ln -s /code/encyclopedia-$VERSION-executable.jar ./encyclopedia.jar
+RUN ln -s /code/encyclopedia-$VERSION-executable.jar /code/encyclopedia.jar
 
 # Set the path. NextFlow seems to circumvent the conda environment
 # We also need to set options for the JRE here.

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,7 @@ channels:
   - conda-forge
   - r
 dependencies:
-  # Main dependencies:
-  - openjdk=11.0.15
-  - encyclopedia=1.12.34
   - bioconductor-msstats=4.2.0
-  - r-tidyverse
+  - r-dplyr
+  - r-tidyr
+  - r-magrittr

--- a/modules/encyclopedia.nf
+++ b/modules/encyclopedia.nf
@@ -43,8 +43,6 @@ process ENCYCLOPEDIA_LOCAL {
 
     script:
     """
-    echo \${PATH} 1>&2
-    which EncyclopeDIA
     gzip -df ${mzml_gz_file}
     ${execEncyclopedia(task.memory)} \\
         -i ${mzml_gz_file.baseName} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,7 +23,7 @@ params {
     encyclopedia.quant_postfix = 'quant'
     encyclopedia.local.args = '-frag HCD'
     encyclopedia.global.args = ''
-    encyclopedia.jar = 'encyclopedia.jar'
+    encyclopedia.jar = '/code/encyclopedia.jar'
 
     // Parameters for msconvert
     msconvert.demultiplex = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,7 +23,7 @@ params {
     encyclopedia.quant_postfix = 'quant'
     encyclopedia.local.args = '-frag HCD'
     encyclopedia.global.args = ''
-    encyclopedia.jar = null
+    encyclopedia.jar = 'encyclopedia.jar'
 
     // Parameters for msconvert
     msconvert.demultiplex = true


### PR DESCRIPTION
For whatever reason, the OpenJDK version used in conda doesn't work with EncyclopeDIA on AWS Batch.

This update uses the official EncyclopeDIA image and adds the other things we need to it.