### PR TITLE
removed row names from msstats proteins output

### DIFF
--- a/bin/msstats.R
+++ b/bin/msstats.R
@@ -116,7 +116,7 @@ main <- function() {
   quants <- quantification(processed, use_log_file = FALSE)
   write.table(quants,
               "results/msstats.proteins.txt",
-              row.names = TRUE,
+              row.names = FALSE,
               quote = FALSE,
               sep = "\t")
 


### PR DESCRIPTION

Discussed here:
https://github.com/TalusBio/nf-encyclopedia/issues/29

Also awaiting for internal discussion to make sure it does not break downstream tools