### PR TITLE
added plattaform to dockerfile build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added 
+
+- 
+
+### Fixed
+
+- Fixed issue where the docker image would not build in M1 macs.
+- Excel compatibility error due to row names in msstats ouput.
+
 ## [1.0.0] - 2022-10-03
 ### Changed
 - Renamed `params.ms_file_csv` to `params.input`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=1.12.34
 
-FROM mambaorg/micromamba:latest as micromamba
-FROM searlelab/encyclopedia:$VERSION
+FROM --platform=linux/amd64 mambaorg/micromamba:latest as micromamba
+FROM --platform=linux/amd64 searlelab/encyclopedia:$VERSION
 LABEL authors="wfondrie@talus.bio" \
       description="Docker image for most of nf-encyclopedia"
 


### PR DESCRIPTION
discussed internally :D

Fixes an issue where micromamba would not be "findable" in the build process in (my) M1 mac.

```
#19 [stage-1 13/14] RUN micromamba install -y -n base -f /tmp/environment.yml &&     micromamba clean --all --yes
#19 sha256:b2fa2e2ed8737c6aeb84133a00ad074f607e0fb19af68b2d4bc0b69128ba6c5f
#19 0.143 /bin/sh: 1: micromamba: not found
#19 ERROR: executor failed running [/bin/sh -c micromamba install -y -n base -f /tmp/environment.yml &&     micromamba clean --all --yes]: exit code: 127
------
 > [stage-1 13/14] RUN micromamba install -y -n base -f /tmp/environment.yml &&     micromamba clean --all --yes:
------
executor failed running [/bin/sh -c micromamba install -y -n base -f /tmp/environment.yml &&     micromamba clean --all --yes]: exit code: 127
```

Note: I still do not know the root cause of the issue but this fixes it ...